### PR TITLE
github projects

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/bytedance/sonic v1.11.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -50,6 +50,8 @@ github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0k
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
+github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -390,6 +392,7 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-sqlite3 v1.14.5 h1:1IdxlwTNazvbKJQSxoJ5/9ECbEeaTTyeU7sEAZ5KKTQ=
 github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/merico-dev/graphql v0.0.0-20240807070533-1cafa544cd5d h1:FpP+YRQudZtnrnIaFvVc87D/WVI7tWi0hBrnRCY8wmQ=
@@ -433,6 +436,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
 github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -447,6 +451,7 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=

--- a/backend/plugins/github/models/migrationscripts/20240613_add_github_project_item.go
+++ b/backend/plugins/github/models/migrationscripts/20240613_add_github_project_item.go
@@ -1,0 +1,25 @@
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+)
+
+type addGithubProjectItems20240613 struct{}
+
+func (*addGithubProjectItems20240613) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&models.GithubProjectItem{},
+	)
+}
+
+func (*addGithubProjectItems20240613) Version() uint64 {
+	return 20240613000000
+}
+
+func (*addGithubProjectItems20240613) Name() string {
+	return "add table _tool_github_project_items"
+}

--- a/backend/plugins/github/models/migrationscripts/register.go
+++ b/backend/plugins/github/models/migrationscripts/register.go
@@ -55,5 +55,6 @@ func All() []plugin.MigrationScript {
 		new(addIsDraftToPr),
 		new(changeIssueComponentType),
 		new(addIndexToGithubJobs),
+		new(addGithubProjectItems20240613),
 	}
 }

--- a/backend/plugins/github/models/project_item.go
+++ b/backend/plugins/github/models/project_item.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/models/common"
+	"gorm.io/datatypes"
+)
+
+type GithubProjectItem struct {
+	ConnectionId  uint64 `gorm:"primaryKey"`
+	ProjectItemId string `gorm:"primaryKey"`
+	ProjectTitle  string
+	ProjectNumber int
+	Title         string
+	Body          string
+	Author        string
+	IsArchived    bool
+	Type          string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	ClosedAt      *time.Time
+	Merged        *bool
+	Assignees     *string           // Comma-separated list of assignee names
+	Milestone     *string           // Milestone title
+	Repository    *string           `gorm:"type:varchar(255)"` // Repository name
+	DynamicFields datatypes.JSONMap `gorm:"type:json"`
+	common.NoPKModel
+}
+
+func (GithubProjectItem) TableName() string {
+	return "_tool_github_project_items"
+}

--- a/backend/plugins/github/tasks/cicd_job_convertor.go
+++ b/backend/plugins/github/tasks/cicd_job_convertor.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -87,10 +86,11 @@ func ConvertJobs(taskCtx plugin.SubTaskContext) (err errors.Error) {
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			line := inputRow.(*models.GithubJob)
 
-			createdAt := time.Now()
-			if line.StartedAt != nil {
-				createdAt = *line.StartedAt
+			// Skip jobs with no started_at value (workaround for https://github.com/apache/incubator-devlake/issues/8442)
+			if line.StartedAt == nil {
+				return nil, nil
 			}
+			createdAt := *line.StartedAt
 			domainJob := &devops.CICDTask{
 				DomainEntity: domainlayer.DomainEntity{Id: jobIdGen.Generate(data.Options.ConnectionId, line.RunID,
 					line.ID)},

--- a/backend/plugins/github/tasks/cicd_job_extractor.go
+++ b/backend/plugins/github/tasks/cicd_job_extractor.go
@@ -62,6 +62,11 @@ func ExtractJobs(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, err
 			}
 
+			// Skip jobs with no started_at value (workaround for https://github.com/apache/incubator-devlake/issues/8442)
+			if githubJob.StartedAt != nil && (githubJob.StartedAt.IsZero() || githubJob.StartedAt.Year() < 1980) {
+				return make([]interface{}, 0, 1), nil
+			}
+
 			results := make([]interface{}, 0, 1)
 			githubJobResult := &models.GithubJob{
 				ConnectionId:  data.Options.ConnectionId,

--- a/backend/plugins/github/tasks/task_data.go
+++ b/backend/plugins/github/tasks/task_data.go
@@ -35,6 +35,7 @@ type GithubOptions struct {
 	Name          string                    `json:"name"  mapstructure:"name,omitempty"`
 	FullName      string                    `json:"fullName"  mapstructure:"fullName,omitempty"`
 	ScopeConfig   *models.GithubScopeConfig `mapstructure:"scopeConfig,omitempty" json:"scopeConfig"`
+	ProjectNumber *int                      `json:"projectNumber" mapstructure:"projectNumber,omitempty"`
 }
 
 type GithubTaskData struct {

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -140,6 +140,10 @@ func (p GithubGraphql) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectReleaseMeta,
 		tasks.ExtractReleasesMeta,
 		githubTasks.ConvertReleasesMeta,
+
+		// github projects
+		tasks.CollectProjectsMeta,
+		tasks.ExtractProjectsMeta,
 	}
 }
 
@@ -175,9 +179,11 @@ func (p GithubGraphql) PrepareTaskData(taskCtx plugin.TaskContext, options map[s
 		return nil, errors.Default.Wrap(err, "unable to get github API client instance")
 	}
 
-	err = githubImpl.EnrichOptions(taskCtx, &op, apiClient.ApiClient)
-	if err != nil {
-		return nil, err
+	if op.ProjectNumber == nil {
+		err = githubImpl.EnrichOptions(taskCtx, &op, apiClient.ApiClient)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	tokens := strings.Split(connection.Token, ",")
@@ -243,14 +249,16 @@ func (p GithubGraphql) PrepareTaskData(taskCtx plugin.TaskContext, options map[s
 	})
 
 	regexEnricher := helper.NewRegexEnricher()
-	if err = regexEnricher.TryAdd(devops.DEPLOYMENT, op.ScopeConfig.DeploymentPattern); err != nil {
-		return nil, errors.BadInput.Wrap(err, "invalid value for `deploymentPattern`")
-	}
-	if err = regexEnricher.TryAdd(devops.PRODUCTION, op.ScopeConfig.ProductionPattern); err != nil {
-		return nil, errors.BadInput.Wrap(err, "invalid value for `productionPattern`")
-	}
-	if err = regexEnricher.TryAdd(devops.ENV_NAME_PATTERN, op.ScopeConfig.EnvNamePattern); err != nil {
-		return nil, errors.BadInput.Wrap(err, "invalid value for `envNamePattern`")
+	if op.ProjectNumber == nil {
+		if err = regexEnricher.TryAdd(devops.DEPLOYMENT, op.ScopeConfig.DeploymentPattern); err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `deploymentPattern`")
+		}
+		if err = regexEnricher.TryAdd(devops.PRODUCTION, op.ScopeConfig.ProductionPattern); err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `productionPattern`")
+		}
+		if err = regexEnricher.TryAdd(devops.ENV_NAME_PATTERN, op.ScopeConfig.EnvNamePattern); err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `envNamePattern`")
+		}
 	}
 
 	taskData := &githubTasks.GithubTaskData{

--- a/backend/plugins/github_graphql/model/migrationscripts/20240808_flush_rawdata.go
+++ b/backend/plugins/github_graphql/model/migrationscripts/20240808_flush_rawdata.go
@@ -38,6 +38,7 @@ func (*flushRawData) Up(basicRes context.BasicRes) errors.Error {
 		"_raw_github_graphql_jobs",
 		"_raw_github_graphql_prs",
 		"_raw_github_graphql_release",
+		"_raw_github_graphql_projects",
 	)
 	return nil
 }

--- a/backend/plugins/github_graphql/tasks/job_extractor.go
+++ b/backend/plugins/github_graphql/tasks/job_extractor.go
@@ -62,6 +62,12 @@ func ExtractJobs(taskCtx plugin.SubTaskContext) errors.Error {
 				if err != nil {
 					taskCtx.GetLogger().Error(err, `Marshal checkRun.Steps.Nodes fail and ignore`)
 				}
+
+				// Skip jobs with no started_at value (workaround for https://github.com/apache/incubator-devlake/issues/8442)
+				if checkRun.StartedAt != nil && (checkRun.StartedAt.IsZero() || checkRun.StartedAt.Year() < 1980) {
+					continue
+				}
+
 				githubJob := &models.GithubJob{
 					ConnectionId: data.Options.ConnectionId,
 					RunID:        checkSuite.CheckSuite.WorkflowRun.DatabaseId,

--- a/backend/plugins/github_graphql/tasks/project_collector.go
+++ b/backend/plugins/github_graphql/tasks/project_collector.go
@@ -1,0 +1,336 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+
+	// "strings"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/github/tasks"
+	"github.com/merico-dev/graphql"
+)
+
+const RAW_PROJECTS_TABLE = "github_graphql_projects"
+
+// QueryProject lists project items in a project
+//
+//	organization(login: "grafana") {
+//		projectV2(number: 218) {
+//			items(first: 50) {
+//					totalCount
+//					nodes {
+//							id
+//							createdAt
+//					}
+//			},
+//			fields(first: 50) {
+//				totalCount
+//				nodes{
+//			 	... on ProjectV2FieldCommon {
+//					 name
+//					 dataType
+//			 	}
+//				}
+//			},
+//		}
+//	}
+type QueryProject struct {
+	RateLimit struct {
+		Cost int
+	}
+	Organization struct {
+		ProjectV2 struct {
+			Fields struct {
+				TotalCount int64
+				Nodes      []Field
+				PageInfo   api.GraphqlQueryPageInfo
+			} `graphql:"fields(first: 100)"`
+			Items struct {
+				// Edges
+				TotalCount graphql.Int
+				Nodes      []ProjectItem
+				PageInfo   api.GraphqlQueryPageInfo
+			} `graphql:"items(first: 100, after: $cursor)"`
+		} `graphql:"projectV2(number: $number)"`
+	} `graphql:"organization(login: $login)"`
+}
+
+// ProjectItem is a GitHub project item
+type ProjectItem struct {
+	Content     ProjectV2ItemContent
+	FieldValues FieldValues `graphql:"fieldValues(first: 100)"`
+	ID          string
+	IsArchived  bool
+	Type        string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Project     ProjectMeta
+	Author      Author `graphql:"creator"`
+}
+
+type ProjectMeta struct {
+	ID     string
+	Number int
+	Title  string
+}
+
+// ProjectV2ItemContent contains Content for a ProjectItem
+type ProjectV2ItemContent struct {
+	DraftIssue  DraftContent       `graphql:"... on DraftIssue"`
+	Issue       IssueContent       `graphql:"... on Issue"`
+	PullRequest PullRequestContent `graphql:"... on PullRequest"`
+}
+
+// DraftContent of the ProjectItem
+type DraftContent struct {
+	Title     *string
+	Body      *string
+	CreatedAt *time.Time
+	Assignees *Assignees `graphql:"assignees(first: 10)"`
+}
+
+// IssuePrContent of the ProjectItem
+type IssueContent struct {
+	Title      *string
+	Body       *string
+	CreatedAt  *time.Time
+	Assignees  *Assignees `graphql:"assignees(first: 10)"`
+	Milestone  *Milestone
+	ClosedAt   *time.Time
+	Repository *Repository
+}
+
+// IssuePrContent of the ProjectItem
+type PullRequestContent struct {
+	Title      *string
+	Body       *string
+	CreatedAt  *time.Time
+	Assignees  *Assignees `graphql:"assignees(first: 10)"`
+	Milestone  *Milestone
+	ClosedAt   *time.Time
+	Merged     *bool
+	Repository *Repository
+}
+
+// Milestone is a GitHub Milestone
+type Milestone struct {
+	Closed  bool
+	Creator struct {
+		User User `graphql:"... on User"`
+	}
+	DueOn     time.Time
+	ClosedAt  time.Time
+	CreatedAt time.Time
+	State     string
+	Title     string
+}
+
+// Assignees to the ProjectItem
+type Assignees struct {
+	PageInfo   api.GraphqlQueryPageInfo
+	TotalCount int64
+	Nodes      []User
+}
+
+// ProjectItemsWithFields ...
+type ProjectItemsWithFields struct {
+	Items  []ProjectItem
+	Fields []Field
+}
+
+// FieldValues are the values of each Field of a ProjectItem
+type FieldValues struct {
+	PageInfo   api.GraphqlQueryPageInfo
+	TotalCount int64
+	Nodes      []FieldValue
+}
+
+// Field is a field on a ProjectItem
+type Field struct {
+	Common ProjectV2FieldCommon `graphql:"... on ProjectV2FieldCommon"`
+}
+
+// FieldValue is a value for a Field
+type FieldValue struct {
+	DateValue      ProjectV2ItemFieldDateValue         `graphql:"... on ProjectV2ItemFieldDateValue"`
+	TextValue      ProjectV2ItemFieldTextValue         `graphql:"... on ProjectV2ItemFieldTextValue"`
+	SelectValue    ProjectV2ItemFieldSingleSelectValue `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	IterationValue ProjectV2ItemFieldIterationValue    `graphql:"... on ProjectV2ItemFieldIterationValue"`
+	LabelsValue    ProjectV2ItemFieldLabelValue        `graphql:"... on ProjectV2ItemFieldLabelValue"`
+	NumberValue    ProjectV2ItemFieldNumberValue       `graphql:"... on ProjectV2ItemFieldNumberValue"`
+	ReviewerValue  ProjectV2ItemFieldReviewerValue     `graphql:"... on ProjectV2ItemFieldReviewerValue"`
+	RepoValue      ProjectV2ItemFieldRepositoryValue   `graphql:"... on ProjectV2ItemFieldRepositoryValue"`
+}
+
+// ProjectV2ItemFieldRepositoryValue ...
+type ProjectV2ItemFieldRepositoryValue struct {
+	Repository Repository
+	Field      CommonField
+}
+
+// Repository is a code repository
+type Repository struct {
+	Name string
+}
+
+// ProjectV2ItemFieldReviewerValue ...
+type ProjectV2ItemFieldReviewerValue struct {
+	Reviewers `graphql:"reviewers(first: 10)"`
+	Field     CommonField
+}
+
+// Reviewers ...
+type Reviewers struct {
+	Nodes []Reviewer
+}
+
+// Reviewer ...
+type Reviewer struct {
+	User `graphql:"... on User"`
+}
+
+// Project item author
+type Author struct {
+	Login string
+}
+
+// ProjectV2ItemFieldNumberValue is a value for a Number field
+type ProjectV2ItemFieldNumberValue struct {
+	Number *float64
+	Field  CommonField
+}
+
+// ProjectV2ItemFieldLabelValue is a value for a Labels field
+type ProjectV2ItemFieldLabelValue struct {
+	ProjectLabels `graphql:"labels(first: 10)"`
+	Field         CommonField
+}
+
+// ProjectLabels ...
+type ProjectLabels struct {
+	Nodes []ProjectLabel
+}
+
+// ProjectLabel ...
+type ProjectLabel struct {
+	Name string
+}
+
+// ProjectV2ItemFieldIterationValue is a value for an Iteration field
+type ProjectV2ItemFieldIterationValue struct {
+	Title *string
+	Field CommonField
+}
+
+// ProjectV2ItemFieldSingleSelectValue is a value for a SingleSelect field
+type ProjectV2ItemFieldSingleSelectValue struct {
+	Name  *string
+	Field CommonField
+}
+
+// CommonField ...
+type CommonField struct {
+	Common ProjectV2FieldCommon `graphql:"... on ProjectV2FieldCommon"`
+}
+
+// ProjectV2ItemFieldTextValue is a value for a Text field
+type ProjectV2ItemFieldTextValue struct {
+	Text  *string
+	Field CommonField
+}
+
+// ProjectV2ItemFieldDateValue is a value for a Date field
+type ProjectV2ItemFieldDateValue struct {
+	CreatedAt time.Time
+	Date      *string
+	UpdatedAt time.Time
+	Field     CommonField
+}
+
+// ProjectV2FieldCommon is common to fields
+type ProjectV2FieldCommon struct {
+	Name     string
+	DataType string
+}
+
+var CollectProjectsMeta = plugin.SubTaskMeta{
+	Name:             "Collect Projects",
+	EntryPoint:       CollectProjects,
+	EnabledByDefault: false,
+	Description:      "Collect GitHub Projects data from GraphQL API and save to raw table.",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CODE},
+}
+
+var _ plugin.SubTaskEntryPoint = CollectProjects
+
+func CollectProjects(taskCtx plugin.SubTaskContext) errors.Error {
+	data := taskCtx.GetData().(*tasks.GithubTaskData)
+	var err errors.Error
+
+	apiCollector, err := api.NewStatefulApiCollector(api.RawDataSubTaskArgs{
+		Ctx: taskCtx,
+		Params: map[string]interface{}{
+			"ConnectionId":  data.Options.ConnectionId,
+			"Owner":         data.Options.Owner,
+			"ProjectNumber": data.Options.ProjectNumber,
+		},
+		Table: RAW_PROJECTS_TABLE,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = apiCollector.InitGraphQLCollector(api.GraphqlCollectorArgs{
+		GraphqlClient: data.GraphqlClient,
+		PageSize:      50,
+		BuildQuery: func(reqData *api.GraphqlRequestData) (interface{}, map[string]interface{}, error) {
+			query := &QueryProject{}
+			if reqData == nil {
+				return query, map[string]interface{}{}, nil
+			}
+			variables := map[string]interface{}{
+				"number": graphql.Int(*data.Options.ProjectNumber),
+				"login":  graphql.String(data.Options.Owner),
+				"cursor": (*graphql.String)(reqData.Pager.SkipCursor),
+			}
+			return query, variables, nil
+		},
+		GetPageInfo: func(iQuery interface{}, args *api.GraphqlCollectorArgs) (*api.GraphqlQueryPageInfo, error) {
+			query := iQuery.(*QueryProject)
+			return &query.Organization.ProjectV2.Items.PageInfo, nil
+		},
+		ResponseParser: func(queryWrapper any) (messages []json.RawMessage, err errors.Error) {
+			query := queryWrapper.(*QueryProject)
+			items := query.Organization.ProjectV2.Items.Nodes
+			for _, item := range items {
+				messages = append(messages, errors.Must1(json.Marshal(item)))
+			}
+			return
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return apiCollector.Execute()
+}

--- a/backend/plugins/github_graphql/tasks/project_extractor.go
+++ b/backend/plugins/github_graphql/tasks/project_extractor.go
@@ -1,0 +1,238 @@
+package tasks
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/github/models"
+	"github.com/apache/incubator-devlake/plugins/github/tasks"
+	"github.com/araddon/dateparse"
+	"gorm.io/datatypes"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractProjects
+
+var ExtractProjectsMeta = plugin.SubTaskMeta{
+	Name:             "Extract Projects",
+	EntryPoint:       ExtractProjects,
+	EnabledByDefault: false,
+	Description:      "Extract raw GitHub Project items into tool layer table github_project_items (with dynamic fields as JSON)",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CODE},
+}
+
+func ExtractProjects(taskCtx plugin.SubTaskContext) errors.Error {
+	data := taskCtx.GetData().(*tasks.GithubTaskData)
+
+	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
+		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: map[string]interface{}{
+				"ConnectionId":  data.Options.ConnectionId,
+				"Owner":         data.Options.Owner,
+				"ProjectNumber": data.Options.ProjectNumber,
+			},
+			Table: RAW_PROJECTS_TABLE,
+		},
+		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
+			rawItem := &ProjectItem{}
+			err := errors.Convert(json.Unmarshal(row.Data, rawItem))
+			if err != nil {
+				return nil, err
+			}
+
+			// collect dynamic fields into a map
+			dynFields := map[string]interface{}{}
+			for _, fv := range rawItem.FieldValues.Nodes {
+				name, val := nameValue(fv)
+				dynFields[name] = val
+			}
+
+			project := &models.GithubProjectItem{
+				ConnectionId:  data.Options.ConnectionId,
+				ProjectItemId: rawItem.ID,
+				ProjectTitle:  rawItem.Project.Title,
+				ProjectNumber: rawItem.Project.Number,
+				Title:         getProjectItemTitle(rawItem),
+				Body:          getProjectItemBody(rawItem),
+				Author:        rawItem.Author.Login,
+				IsArchived:    rawItem.IsArchived,
+				Type:          rawItem.Type,
+				CreatedAt:     rawItem.CreatedAt,
+				UpdatedAt:     rawItem.UpdatedAt,
+				ClosedAt:      closedDate(rawItem.Content),
+				Merged:        isMerged(rawItem.Content),
+				Repository:    getProjectItemRepo(rawItem),
+				Assignees:     getAssignees(rawItem.Content),
+				Milestone:     milestone(rawItem.Content),
+				DynamicFields: datatypes.JSONMap(dynFields),
+			}
+
+			return []interface{}{project}, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+// Helper functions to extract title/body from ProjectItem content
+func getProjectItemTitle(item *ProjectItem) string {
+	if item.Content.DraftIssue.Title != nil {
+		return *item.Content.DraftIssue.Title
+	}
+	if item.Content.Issue.Title != nil {
+		return *item.Content.Issue.Title
+	}
+	if item.Content.PullRequest.Title != nil {
+		return *item.Content.PullRequest.Title
+	}
+	return ""
+}
+
+// getProjectItemBody extracts the body from the ProjectItem content
+func getProjectItemBody(item *ProjectItem) string {
+	if item.Content.DraftIssue.Body != nil {
+		return *item.Content.DraftIssue.Body
+	}
+	if item.Content.Issue.Body != nil {
+		return *item.Content.Issue.Body
+	}
+	if item.Content.PullRequest.Body != nil {
+		return *item.Content.PullRequest.Body
+	}
+	return ""
+}
+
+func getProjectItemRepo(item *ProjectItem) *string {
+	if item.Content.Issue.Repository != nil {
+		return &item.Content.Issue.Repository.Name
+	}
+	if item.Content.PullRequest.Repository != nil {
+		return &item.Content.PullRequest.Repository.Name
+	}
+	return nil
+}
+
+// convert fieldValue to time
+func date(fv FieldValue) *time.Time {
+	if fv.DateValue.Date == nil {
+		return nil
+	}
+	t, err := dateparse.ParseAny(*fv.DateValue.Date)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// get closed date from the content
+func closedDate(content ProjectV2ItemContent) *time.Time {
+	if content.Issue.ClosedAt != nil {
+		return content.Issue.ClosedAt
+	}
+	if content.PullRequest.ClosedAt != nil {
+		return content.PullRequest.ClosedAt
+	}
+	return nil
+}
+
+// convert list of assignees to comma delimited string
+func getAssignees(content ProjectV2ItemContent) *string {
+	// if content.Issue.CreatedAt != nil {
+	// 	return assignees(content.Issue)
+	// }
+	if content.Issue.CreatedAt != nil {
+		return assignees(content.Issue.Assignees)
+	}
+	if content.DraftIssue.CreatedAt != nil {
+		return assignees(content.DraftIssue.Assignees)
+	}
+	if content.PullRequest.CreatedAt != nil {
+		return assignees(content.PullRequest.Assignees)
+	}
+	return nil
+}
+
+func assignees(assignees *Assignees) *string {
+	var _assignees []string
+	for _, v := range assignees.Nodes {
+		_assignees = append(_assignees, v.Name)
+	}
+	names := strings.Join(_assignees, ",")
+	return &names
+}
+
+// get milestone as string from the model
+func milestone(content ProjectV2ItemContent) *string {
+	if content.Issue.CreatedAt != nil && content.Issue.Milestone != nil {
+		return &content.Issue.Milestone.Title
+	}
+	if content.PullRequest.CreatedAt != nil && content.PullRequest.Milestone != nil {
+		return &content.PullRequest.Milestone.Title
+	}
+	return nil
+}
+
+// convert list of labels to comma delimited string
+func labels(fv FieldValue) *string {
+	if fv.LabelsValue.Nodes != nil {
+		var labels []string
+		for _, l := range fv.LabelsValue.Nodes {
+			labels = append(labels, l.Name)
+		}
+		val := strings.Join(labels, ",")
+		return &val
+	}
+	return nil
+}
+
+// convert list of reviewers to comma delimited string
+func reviewers(fv FieldValue) *string {
+	if fv.ReviewerValue.Nodes != nil {
+		var vals []string
+		for _, r := range fv.ReviewerValue.Nodes {
+			vals = append(vals, r.Name)
+		}
+		val := strings.Join(vals, ",")
+		return &val
+	}
+	return nil
+}
+
+func isMerged(content ProjectV2ItemContent) *bool {
+	if content.PullRequest.Merged != nil {
+		return content.PullRequest.Merged
+	}
+	return nil
+}
+
+// get the field name and value from the response model
+func nameValue(fv FieldValue) (string, any) {
+	// DateValue, SelectValue, TextValue etc all have the field data type
+	dataType := fv.DateValue.Field.Common.DataType
+	switch dataType {
+	case "DATE":
+		return fv.DateValue.Field.Common.Name, date(fv)
+	case "SINGLE_SELECT":
+		return fv.SelectValue.Field.Common.Name, fv.SelectValue.Name
+	case "TEXT", "TITLE":
+		return fv.TextValue.Field.Common.Name, fv.TextValue.Text
+	case "ITERATION":
+		return fv.IterationValue.Field.Common.Name, fv.IterationValue.Title
+	case "LABELS":
+		return fv.LabelsValue.Field.Common.Name, labels(fv)
+	case "NUMBER":
+		return fv.NumberValue.Field.Common.Name, fv.NumberValue.Number
+	case "REVIEWERS":
+		return fv.ReviewerValue.Field.Common.Name, reviewers(fv)
+	case "REPOSITORY":
+		return fv.RepoValue.Field.Common.Name, &fv.RepoValue.Repository.Name
+	}
+	return fv.DateValue.Field.Common.Name, nil
+}

--- a/config-ui/src/routes/blueprint/detail/components/advanced-editor/example/githubproject.ts
+++ b/config-ui/src/routes/blueprint/detail/components/advanced-editor/example/githubproject.ts
@@ -1,0 +1,19 @@
+const github_project = [
+  [
+    {
+      plugin: 'github_graphql',
+      subtasks: [
+        "Collect Projects",
+        "Extract Projects"
+      ],
+      options: {
+        connectionId: 1,
+        owner: "rainlanguage",
+        projectNumber: 4
+      },
+    },
+  ],
+];
+
+
+export default github_project;

--- a/config-ui/src/routes/blueprint/detail/components/advanced-editor/example/index.ts
+++ b/config-ui/src/routes/blueprint/detail/components/advanced-editor/example/index.ts
@@ -22,6 +22,7 @@ import feishu from './feishu';
 import general from './general';
 import gitextractor from './gitextractor';
 import github from './github';
+import github_project from './githubproject';
 import gitlab from './gitlab';
 import jenkins from './jenkins';
 import jira from './jira';
@@ -50,6 +51,11 @@ export const EXAMPLE_CONFIG = [
     id: 'github',
     name: 'Load GitHub Configuration',
     config: github,
+  },
+  {
+    id: 'github-project',
+    name: 'Load GitHub Project/Board (aka GitHub ProjectV2) Configuration',
+    config: github_project,
   },
   {
     id: 'gitlab',

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,20 @@
 
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = [ pkgs.go pkgs.gopls ];
+          shellHook = 
+            # there is a known issue with nix pkgs new apple_sdk and that since it is now using xcrun,
+            # apple_sdk's setup hook breaks the link to some of '/usr/bin' Xcode command line tools bins
+            # and libs, this mainly is an issue for `tauri-shell` devshell when tauri cli is used to build
+            # a tauri app for macos where it needs one of those bins called `SetFile`, for more details:
+            # https://github.com/NixOS/nixpkgs/issues/355486
+            #
+            # this is a workaround that removes xcrun from devshell PATH and unsets DEVELOPER_DIR so that
+            # those apple bins and libs are accessible normally through `/usr/bin`
+            (if pkgs.stdenv.isDarwin then ''
+              export PATH=''${PATH//'${pkgs.xcbuild.xcrun}/bin:'/}
+              unset DEVELOPER_DIR
+            '' else
+              "");
         };
       });
 }


### PR DESCRIPTION
This PR implements functionalities needed to pull and store guthub projects data from github graphql API.

for creating a pipeline that pulls github projects, just create a advanced pipeline that, and select github_projects template json from the list, and configure it to rainlanguage, our main kanban id is 4, after that, once the data is fetched, on grafana, you can simply write mysql queries to pull data from the db, the github projects table in the db is called `_tool_guthub_project_items`, some columns of the table are stored as json as they are dynamic, to show them as column on grafana, you can add json transformers to the query in grafana dashboard, that will automatically parse the selected json column and set the result as separate columns in grafana


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for collecting and extracting GitHub ProjectV2 (board) data via new subtasks in the GitHub GraphQL plugin.
  - Introduced a new database table for storing GitHub project items and enhanced backend models to support project metadata.
  - Provided a new example configuration in the UI for loading GitHub Project/Board data.

- **Bug Fixes**
  - Improved compatibility for macOS development environments by adjusting environment variables in the development shell.
  - Excluded CI/CD jobs without valid start timestamps from processing to prevent inaccurate job creation dates.

- **Chores**
  - Updated dependencies to support date parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->